### PR TITLE
Automatically focus GuiTextfield in GuiStackSelectorExtension

### DIFF
--- a/src/main/java/com/creativemd/creativecore/common/gui/controls/gui/GuiTextfield.java
+++ b/src/main/java/com/creativemd/creativecore/common/gui/controls/gui/GuiTextfield.java
@@ -49,6 +49,7 @@ public class GuiTextfield extends GuiFocusControl {
 	public GuiTextfield(String name, String text, int x, int y, int width, int height) {
 		super(name, x, y, width, height);
 		this.text = text;
+		this.focused = true;
 	}
 	
 	public GuiTextfield setFloatOnly() {

--- a/src/main/java/com/creativemd/creativecore/common/gui/controls/gui/GuiTextfield.java
+++ b/src/main/java/com/creativemd/creativecore/common/gui/controls/gui/GuiTextfield.java
@@ -49,7 +49,6 @@ public class GuiTextfield extends GuiFocusControl {
 	public GuiTextfield(String name, String text, int x, int y, int width, int height) {
 		super(name, x, y, width, height);
 		this.text = text;
-		this.focused = true;
 	}
 	
 	public GuiTextfield setFloatOnly() {

--- a/src/main/java/com/creativemd/creativecore/common/gui/controls/gui/custom/GuiStackSelectorExtension.java
+++ b/src/main/java/com/creativemd/creativecore/common/gui/controls/gui/custom/GuiStackSelectorExtension.java
@@ -67,6 +67,7 @@ public class GuiStackSelectorExtension extends GuiComboBoxExtension {
 				textfield = new GuiTextfield("searchBar", search == null ? "" : search, 3, height, width - 20, 10);
 			controls.add(textfield);
 			height += textfield.height;
+			textfield.focused = true;
 		}
 		
 		for (Entry<String, ArrayList<ItemStack>> entry : stacks.entrySet()) {


### PR DESCRIPTION
This is a pretty small tweak. It automatically focuses the text field in the stack selector combo box.

When the user expands a stack selector combo box, the cursor is automatically placed in the text box and ready for the block name to be typed. Fewer clicks mean faster block changes.

It has been tested to ensure that the selection does not take effect before the combo box is expanded, however with no mechanism to actually select blocks outside of the mouse this wouldn't be an issue anyway.