### PR TITLE
Scale parameter on GuiWidgets with text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
+.idea
 
 # Package Files #
 *.jar

--- a/src/main/java/team/creative/creativecore/client/render/GuiRenderHelper.java
+++ b/src/main/java/team/creative/creativecore/client/render/GuiRenderHelper.java
@@ -118,16 +118,22 @@ public class GuiRenderHelper {
             
         }
     }
-    
+
     public static void drawStringCentered(PoseStack stack, String text, float width, float height, int color, boolean shadow) {
-        int textWidth = mc.font.width(text);
+        drawStringCentered(stack, text, 1.0f, width, height, color, shadow);
+    }
+
+    public static void drawStringCentered(PoseStack stack, String text, float scale, float width, float height, int color, boolean shadow) {
+        stack.pushPose();
+        stack.scale(scale, scale, scale);
+        int textWidth = (int) (mc.font.width(text) * scale);
         if (textWidth > width) {
-            int dotWith = mc.font.width("...");
+            int dotWith = (int) (mc.font.width("...") * scale);
             if (textWidth > dotWith) {
                 StringBuilder builder = new StringBuilder();
                 textWidth = 0;
                 for (int i = 0; i < text.length(); i++) {
-                    int charWidth = mc.font.width("" + text.charAt(i));
+                    int charWidth = (int) (mc.font.width("" + text.charAt(i)) * scale);
                     if (charWidth + textWidth + dotWith < width) {
                         builder.append(text.charAt(i));
                         textWidth += charWidth;
@@ -138,9 +144,10 @@ public class GuiRenderHelper {
             }
         }
         BufferSource buffer = MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());
-        mc.font.drawInBatch(text, width / 2 - mc.font.width(text) / 2, height / 2 - mc.font.lineHeight / 2, ColorUtils.WHITE, shadow, stack.last()
+        mc.font.drawInBatch(text, width / 2 - (float) mc.font.width(text) / 2, height / 2 - (float) mc.font.lineHeight / 2, ColorUtils.WHITE, shadow, stack.last()
                 .pose(), buffer, DisplayMode.NORMAL, 0, 15728880);
         buffer.endBatch();
+        stack.popPose();
     }
     
     public static void horizontalGradientRect(PoseStack pose, int x, int y, int x2, int y2, int colorFrom, int colorTo) {

--- a/src/main/java/team/creative/creativecore/client/render/text/CompiledText.java
+++ b/src/main/java/team/creative/creativecore/client/render/text/CompiledText.java
@@ -51,10 +51,9 @@ public class CompiledText {
     }
     
     public static final CompiledText EMPTY = new CompiledText(0, 0) {
-        
         {
-            original = Collections.EMPTY_LIST;
-            lines = Collections.EMPTY_LIST;
+            original = Collections.emptyList();
+            lines = Collections.emptyList();
         }
         
         @Override
@@ -76,12 +75,13 @@ public class CompiledText {
         @OnlyIn(Dist.CLIENT)
         public void render(PoseStack stack) {}
     };
-    
+
     private int maxWidth;
     private int maxHeight;
     private int usedWidth;
     private int usedHeight;
     private int lineSpacing = 2;
+    protected float scale;
     private boolean shadow = true;
     private int defaultColor = ColorUtils.WHITE;
     private Align align = Align.LEFT;
@@ -90,9 +90,14 @@ public class CompiledText {
     protected List<Component> original;
     
     public CompiledText(int width, int height) {
+        this(width, height, 1.0f);
+    }
+
+    public CompiledText(int width, int height, float initialScale) {
         this.maxWidth = width;
         this.maxHeight = height;
-        setText(Collections.EMPTY_LIST);
+        setText(Collections.emptyList());
+        this.scale = initialScale;
     }
     
     public void setMaxHeight(int height) {
@@ -103,6 +108,14 @@ public class CompiledText {
         this.maxWidth = width;
         this.maxHeight = height;
         compile();
+    }
+
+    public float getScale() {
+        return scale;
+    }
+
+    public void setScale(float scale) {
+        this.scale = scale;
     }
     
     public int getMaxWidht() {
@@ -207,13 +220,14 @@ public class CompiledText {
         int totalHeight = getTotalHeight();
         
         stack.pushPose();
+        stack.scale(scale, scale, scale);
         float y = Math.max(0, switch (valign) {
             case CENTER -> maxHeight / 2 - totalHeight / 2;
             case BOTTOM -> maxHeight - totalHeight;
             default -> 0;
         });
         stack.translate(0, y, 0);
-        usedHeight += y;
+        usedHeight += (int) y;
         
         for (CompiledLine line : lines) {
             switch (align) {

--- a/src/main/java/team/creative/creativecore/common/gui/controls/collection/GuiComboBox.java
+++ b/src/main/java/team/creative/creativecore/common/gui/controls/collection/GuiComboBox.java
@@ -12,7 +12,7 @@ import team.creative.creativecore.common.util.math.geo.Rect;
 import team.creative.creativecore.common.util.text.ITextCollection;
 
 public class GuiComboBox extends GuiLabel {
-    
+
     protected GuiComboBoxExtension extension;
     public CompiledText[] lines;
     private int index;
@@ -20,7 +20,11 @@ public class GuiComboBox extends GuiLabel {
     private boolean searchbar;
     
     public GuiComboBox(String name, ITextCollection builder) {
-        super(name);
+        this(name, builder, 1.0f);
+    }
+
+    public GuiComboBox(String name, ITextCollection builder, float scale) {
+        super(name, scale);
         lines = builder.build();
         if (index >= lines.length)
             index = 0;
@@ -82,7 +86,7 @@ public class GuiComboBox extends GuiLabel {
         int width = 0;
         for (CompiledText text : lines)
             width = Math.max(width, text.getTotalWidth() + 3); // +3 due to scroll bar width
-        return width;
+        return (int) (width * scale);
     }
     
     @Override
@@ -90,7 +94,7 @@ public class GuiComboBox extends GuiLabel {
         int height = 0;
         for (CompiledText text : lines)
             height = Math.max(height, text.getTotalHeight());
-        return height;
+        return (int) (height * scale);
     }
     
     public int getIndex() {

--- a/src/main/java/team/creative/creativecore/common/gui/controls/collection/GuiComboBox.java
+++ b/src/main/java/team/creative/creativecore/common/gui/controls/collection/GuiComboBox.java
@@ -86,7 +86,7 @@ public class GuiComboBox extends GuiLabel {
         int width = 0;
         for (CompiledText text : lines)
             width = Math.max(width, text.getTotalWidth() + 3); // +3 due to scroll bar width
-        return (int) (width * scale);
+        return (int) (width * scale) + 3; // +3 due some various font symbol/spacing width
     }
     
     @Override

--- a/src/main/java/team/creative/creativecore/common/gui/controls/simple/GuiButton.java
+++ b/src/main/java/team/creative/creativecore/common/gui/controls/simple/GuiButton.java
@@ -2,6 +2,7 @@ package team.creative.creativecore.common.gui.controls.simple;
 
 import java.util.function.Consumer;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.sounds.SoundEvents;
 import team.creative.creativecore.common.gui.style.ControlFormatting;
 import team.creative.creativecore.common.util.math.geo.Rect;
@@ -31,5 +32,24 @@ public class GuiButton extends GuiLabel {
     public ControlFormatting getControlFormatting() {
         return ControlFormatting.CLICKABLE;
     }
-    
+
+    @Override
+    protected int minWidth(int availableWidth) {
+        return 0;
+    }
+
+    @Override
+    protected int preferredWidth(int availableWidth) {
+        return text.getTotalWidth();
+    }
+
+    @Override
+    protected int minHeight(int width, int availableHeight) {
+        return Minecraft.getInstance().font.lineHeight;
+    }
+
+    @Override
+    protected int preferredHeight(int width, int availableHeight) {
+        return text.getTotalHeight();
+    }
 }

--- a/src/main/java/team/creative/creativecore/common/gui/controls/simple/GuiButton.java
+++ b/src/main/java/team/creative/creativecore/common/gui/controls/simple/GuiButton.java
@@ -11,7 +11,11 @@ public class GuiButton extends GuiLabel {
     protected Consumer<Integer> pressed;
     
     public GuiButton(String name, Consumer<Integer> pressed) {
-        super(name);
+        this(name, 1.0f, pressed);
+    }
+
+    public GuiButton(String name, float scale, Consumer<Integer> pressed) {
+        super(name, scale);
         this.pressed = pressed;
     }
     

--- a/src/main/java/team/creative/creativecore/common/gui/controls/simple/GuiImage.java
+++ b/src/main/java/team/creative/creativecore/common/gui/controls/simple/GuiImage.java
@@ -1,0 +1,80 @@
+package team.creative.creativecore.common.gui.controls.simple;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import team.creative.creativecore.client.render.GuiRenderHelper;
+import team.creative.creativecore.common.gui.GuiChildControl;
+import team.creative.creativecore.common.gui.GuiControl;
+import team.creative.creativecore.common.gui.style.ControlFormatting;
+import team.creative.creativecore.common.gui.style.GuiIcon;
+import team.creative.creativecore.common.gui.style.GuiStyle;
+import team.creative.creativecore.common.gui.style.display.StyleDisplay;
+import team.creative.creativecore.common.util.math.geo.Rect;
+import team.creative.creativecore.common.util.type.Color;
+
+public class GuiImage extends GuiControl {
+    protected GuiIcon icon;
+    protected Color color;
+    protected int preferredWidth;
+    protected int preferredHeight;
+
+    public GuiImage(String name, int width, int height, GuiIcon icon) {
+        super(name);
+        this.preferredWidth = width;
+        this.preferredHeight = height;
+        this.color = Color.WHITE;
+        this.icon = icon;
+    }
+
+    @Override
+    public void init() {}
+
+    @Override
+    public void closed() {}
+
+    @Override
+    public void tick() {}
+
+    @Override
+    public void flowX(int width, int preferred) {}
+
+    @Override
+    public void flowY(int width, int height, int preferred) {}
+
+    @Override
+    protected int preferredWidth(int availableWidth) {
+        return preferredWidth;
+    }
+
+    @Override
+    protected int preferredHeight(int width, int availableHeight) {
+        return preferredHeight;
+    }
+
+    @Override
+    @OnlyIn(Dist.CLIENT)
+    public StyleDisplay getBackground(GuiStyle style, StyleDisplay display) {
+        return StyleDisplay.NONE;
+    }
+
+    @Override
+    public ControlFormatting getControlFormatting() {
+        return ControlFormatting.TRANSPARENT_NO_DISABLE;
+    }
+
+    @Override
+    @OnlyIn(Dist.CLIENT)
+    protected void renderContent(GuiGraphics graphics, GuiChildControl control, Rect rect, int mouseX, int mouseY) {
+        RenderSystem.enableDepthTest();
+        RenderSystem.enableBlend();
+        RenderSystem.defaultBlendFunc();
+        RenderSystem.setShader(GameRenderer::getPositionTexShader);
+        RenderSystem.setShaderTexture(0, this.icon.location());
+        this.color.glColor();
+        GuiRenderHelper.textureRect(graphics.pose(), 0, 0, (int)rect.getWidth(), (int)rect.getHeight(), (float)this.icon.minX(), (float)this.icon.minY(), (float)(this.icon.minX() + this.icon.width()), (float)(this.icon.minY() + this.icon.height()));
+        RenderSystem.disableBlend();
+    }
+}

--- a/src/main/java/team/creative/creativecore/common/gui/controls/simple/GuiLabel.java
+++ b/src/main/java/team/creative/creativecore/common/gui/controls/simple/GuiLabel.java
@@ -118,7 +118,7 @@ public class GuiLabel extends GuiControl {
     
     @Override
     protected int preferredWidth(int availableWidth) {
-        return (int) (text.getTotalWidth() * scale);
+        return (int) (text.getTotalWidth() * scale) + 3;  // +3 due some various font symbol/spacing width
     }
     
     @Override

--- a/src/main/java/team/creative/creativecore/common/gui/controls/simple/GuiLabel.java
+++ b/src/main/java/team/creative/creativecore/common/gui/controls/simple/GuiLabel.java
@@ -18,11 +18,16 @@ import team.creative.creativecore.common.gui.style.ControlFormatting;
 import team.creative.creativecore.common.util.math.geo.Rect;
 
 public class GuiLabel extends GuiControl {
-    
+    protected final float scale;
     protected CompiledText text = CompiledText.createAnySize();
     
     public GuiLabel(String name) {
+        this(name, 1.0f);
+    }
+
+    public GuiLabel(String name, float scale) {
         super(name);
+        this.scale = scale;
     }
     
     public GuiLabel setDefaultColor(int color) {
@@ -92,6 +97,7 @@ public class GuiLabel extends GuiControl {
     @Environment(EnvType.CLIENT)
     @OnlyIn(Dist.CLIENT)
     protected void renderContent(GuiGraphics graphics, GuiChildControl control, Rect rect, int mouseX, int mouseY) {
+        text.setScale(scale);
         text.render(graphics.pose());
     }
     
@@ -112,17 +118,17 @@ public class GuiLabel extends GuiControl {
     
     @Override
     protected int preferredWidth(int availableWidth) {
-        return text.getTotalWidth();
+        return (int) (text.getTotalWidth() * scale);
     }
     
     @Override
     protected int minHeight(int width, int availableHeight) {
-        return Minecraft.getInstance().font.lineHeight;
+        return (int) (Minecraft.getInstance().font.lineHeight * scale);
     }
     
     @Override
     protected int preferredHeight(int width, int availableHeight) {
-        return text.getTotalHeight();
+        return (int) (text.getTotalHeight() * scale);
     }
     
 }

--- a/src/main/java/team/creative/creativecore/common/gui/controls/simple/GuiSlider.java
+++ b/src/main/java/team/creative/creativecore/common/gui/controls/simple/GuiSlider.java
@@ -27,13 +27,19 @@ public class GuiSlider extends GuiControl implements IGuiParent {
     public double maxValue;
     public double minValue;
     public double value;
+    protected float textScale;
     protected boolean grabbedSlider;
     public int sliderWidth = 4;
     
     protected GuiTextfield textfield;
     
     public GuiSlider(String name, double value, double min, double max) {
+        this(name, 1.0f, value, min, max);
+    }
+
+    public GuiSlider(String name, float textScale, double value, double min, double max) {
         super(name);
+        this.textScale = textScale;
         this.minValue = min;
         this.maxValue = max;
         setValue(value);
@@ -194,7 +200,7 @@ public class GuiSlider extends GuiControl implements IGuiParent {
         if (textfield != null)
             textfield.render(graphics, control, rect, rect, 1, mouseX, mouseY);
         else
-            GuiRenderHelper.drawStringCentered(pose, getTextByValue(), control.getContentWidth(), control.getContentHeight(), ColorUtils.WHITE, true);
+            GuiRenderHelper.drawStringCentered(pose, getTextByValue(), textScale, control.getContentWidth(), control.getContentHeight(), ColorUtils.WHITE, true);
     }
     
     @Override

--- a/src/main/java/team/creative/creativecore/common/gui/controls/simple/GuiStateButton.java
+++ b/src/main/java/team/creative/creativecore/common/gui/controls/simple/GuiStateButton.java
@@ -17,15 +17,23 @@ import team.creative.creativecore.common.util.text.TextListBuilder;
 
 public class GuiStateButton extends GuiButton {
     
-    private int index = 0;
+    private int index;
     public CompiledText[] states;
     
     public GuiStateButton(String name, ITextCollection states) {
         this(name, 0, states);
     }
+
+    public GuiStateButton(String name, float scale, ITextCollection states) {
+        this(name, scale, 0, states);
+    }
     
     public GuiStateButton(String name, int index, ITextCollection states) {
-        super(name, null);
+        this(name, 1.0f, index, states);
+    }
+
+    public GuiStateButton(String name, float scale, int index, ITextCollection states) {
+        super(name, scale, null);
         this.pressed = button -> {
             if (button == 1)
                 previousState();

--- a/src/main/java/team/creative/creativecore/common/gui/controls/simple/GuiTextfield.java
+++ b/src/main/java/team/creative/creativecore/common/gui/controls/simple/GuiTextfield.java
@@ -46,7 +46,8 @@ public class GuiTextfield extends GuiFocusControl {
     private int lineScrollOffset;
     private int cursorPosition;
     private int selectionEnd;
-    private String suggestion;
+    protected String suggestion;
+    protected float textScale;
     /** Called to check if the text is valid */
     private Predicate<String> validator = Objects::nonNull;
     private BiFunction<String, Integer, FormattedCharSequence> textFormatter = (text, pos) -> {
@@ -55,13 +56,23 @@ public class GuiTextfield extends GuiFocusControl {
     private int cachedWidth;
     
     public GuiTextfield(String name) {
+        this(name, 1.0f);
+    }
+
+    public GuiTextfield(String name, float textScale) {
         super(name);
         setText("");
+        setTextScale(textScale);
     }
     
     public GuiTextfield(String name, String text) {
+        this(name, text, 1.0f);
+    }
+
+    public GuiTextfield(String name, String text, float textScale) {
         super(name);
         setText(text);
+        setTextScale(textScale);
     }
     
     @Override
@@ -137,6 +148,14 @@ public class GuiTextfield extends GuiFocusControl {
             return 0;
         }
     }
+
+    public float getTextScale() {
+        return textScale;
+    }
+
+    public void setTextScale(float textScale) {
+        this.textScale = textScale;
+    }
     
     @Override
     public void init() {}
@@ -159,6 +178,8 @@ public class GuiTextfield extends GuiFocusControl {
     @OnlyIn(Dist.CLIENT)
     protected void renderContent(GuiGraphics graphics, GuiChildControl control, Rect rect, int mouseX, int mouseY) {
         PoseStack pose = graphics.pose();
+        pose.pushPose();
+        pose.scale(textScale, textScale, textScale);
         Font font = GuiRenderHelper.getFont();
         int j = this.cursorPosition - this.lineScrollOffset;
         int k = this.selectionEnd - this.lineScrollOffset;
@@ -202,6 +223,7 @@ public class GuiTextfield extends GuiFocusControl {
             int l1 = font.width(s.substring(0, k));
             this.drawSelectionBox(control, pose.last().pose(), k1, yOffset - 1, l1 - 1, yOffset + 1 + 9);
         }
+        pose.popPose();
     }
     
     public void setText(String textIn) {


### PR DESCRIPTION
Adds the capability to scale text on Labels and buttons
Labels also affects preferred with and height, because these aren't supposted to be interacted
Otherwhise... buttons aren't affected by textscale and only applies scale to text, these needs to be clickable and is better have a big button but with a small text

EXTRA:
GuiImage class added: exists GuiLabel as a non interactable GuiButton but not a non interactable GuiIconButton counterpart

EXAMPLE (no tested on 1.20.1, i ported code from 1.18.2)
![2023-09-15_23h49_35](https://github.com/CreativeMD/CreativeCore/assets/29090346/74273190-2aad-4c42-a48c-30fd64d99ae8)
