### PR TITLE
fix: tab content is not visible

### DIFF
--- a/src/main/java/team/creative/creativecore/common/gui/control/parent/GuiTabs.java
+++ b/src/main/java/team/creative/creativecore/common/gui/control/parent/GuiTabs.java
@@ -57,6 +57,7 @@ public class GuiTabs extends GuiParent {
         index = select;
         selected = tabs.get(select);
         bar.highlight(select);
+        add(selected);
         if (lastHeight == -1 && getParent() != null)
             reflow();
         else {


### PR DESCRIPTION
this fixes issue that tab content(example: advanced door timeline in littletiles) is not visible