### PR TITLE
fix GuiRenderHelper.drawTextureRect for 1.21.5

### DIFF
--- a/src/main/java/team/creative/creativecore/client/render/GuiRenderHelper.java
+++ b/src/main/java/team/creative/creativecore/client/render/GuiRenderHelper.java
@@ -166,10 +166,10 @@ public class GuiRenderHelper {
         graphics.drawSpecial(consumer -> {
             var matrix = graphics.pose().last().pose();
             VertexConsumer vertexconsumer = consumer.getBuffer(rendertype);
-            vertexconsumer.addVertex(matrix, x, y2, z).setUv(u, v2);
-            vertexconsumer.addVertex(matrix, x2, y2, z).setUv(u2, v2);
-            vertexconsumer.addVertex(matrix, x2, y, z).setUv(u2, v);
-            vertexconsumer.addVertex(matrix, x, y, z).setUv(u, v);
+            vertexconsumer.addVertex(matrix, x, y2, z).setUv(u, v2).setColor(-1);
+            vertexconsumer.addVertex(matrix, x2, y2, z).setUv(u2, v2).setColor(-1);
+            vertexconsumer.addVertex(matrix, x2, y, z).setUv(u2, v).setColor(-1);
+            vertexconsumer.addVertex(matrix, x, y, z).setUv(u, v).setColor(-1);
         });
     }
     
@@ -178,10 +178,10 @@ public class GuiRenderHelper {
         graphics.drawSpecial(consumer -> {
             var matrix = graphics.pose().last().pose();
             VertexConsumer vertexconsumer = consumer.getBuffer(rendertype);
-            vertexconsumer.addVertex(matrix, x, y2, z).setUv(u, v2);
-            vertexconsumer.addVertex(matrix, x2, y2, z).setUv(u2, v2);
-            vertexconsumer.addVertex(matrix, x2, y, z).setUv(u2, v);
-            vertexconsumer.addVertex(matrix, x, y, z).setUv(u, v);
+            vertexconsumer.addVertex(matrix, x, y2, z).setUv(u, v2).setColor(-1);
+            vertexconsumer.addVertex(matrix, x2, y2, z).setUv(u2, v2).setColor(-1);
+            vertexconsumer.addVertex(matrix, x2, y, z).setUv(u2, v).setColor(-1);
+            vertexconsumer.addVertex(matrix, x, y, z).setUv(u, v).setColor(-1);
         });
     }
     


### PR DESCRIPTION
This fixes a crash when the library is using `drawTextureRect`, for example with a `new GuiIcon("my_icon", iconRes)`

stackTrace that it fixes :

```
java.lang.IllegalStateException: Missing elements in vertex: Color
	at TRANSFORMER/minecraft@1.21.5/com.mojang.blaze3d.vertex.BufferBuilder.endLastVertex(BufferBuilder.java:117) ~[neoforge-21.5.75.jar%23221!/:?] {re:classloading,pl:runtimedistcleaner:A}
	at TRANSFORMER/minecraft@1.21.5/com.mojang.blaze3d.vertex.BufferBuilder.beginVertex(BufferBuilder.java:90) ~[neoforge-21.5.75.jar%23221!/:?] {re:classloading,pl:runtimedistcleaner:A}
	at TRANSFORMER/minecraft@1.21.5/com.mojang.blaze3d.vertex.BufferBuilder.addVertex(BufferBuilder.java:144) ~[neoforge-21.5.75.jar%23221!/:?] {re:classloading,pl:runtimedistcleaner:A}
	at TRANSFORMER/minecraft@1.21.5/com.mojang.blaze3d.vertex.VertexConsumer.addVertex(VertexConsumer.java:161) ~[neoforge-21.5.75.jar%23221!/:?] {re:classloading,pl:runtimedistcleaner:A}
	at TRANSFORMER/creativecore@2.13.2/team.creative.creativecore.client.render.GuiRenderHelper.lambda$drawTextureRect$6(GuiRenderHelper.java:170) ~[creativecore-257814-6439252.jar%23226!/:2.13.2] {re:classloading,pl:runtimedistcleaner:A}
	at TRANSFORMER/minecraft@1.21.5/net.minecraft.client.gui.GuiGraphics.drawSpecial(GuiGraphics.java:1088) ~[neoforge-21.5.75.jar%23221!/:?] {re:classloading,pl:runtimedistcleaner:A}
	at TRANSFORMER/creativecore@2.13.2/team.creative.creativecore.client.render.GuiRenderHelper.drawTextureRect(GuiRenderHelper.java:166) ~[creativecore-257814-6439252.jar%23226!/:2.13.2] {re:classloading,pl:runtimedistcleaner:A}
	at TRANSFORMER/creativecore@2.13.2/team.creative.creativecore.client.render.GuiRenderHelper.textureRect(GuiRenderHelper.java:155) ~[creativecore-257814-6439252.jar%23226!/:2.13.2] {re:classloading,pl:runtimedistcleaner:A}
	at TRANSFORMER/creativecore@2.13.2/team.creative.creativecore.common.gui.control.simple.GuiIcon.renderContent(GuiIcon.java:123) ~[creativecore-257814-6439252.jar%23226!/:2.13.2] {re:classloading}
	at TRANSFORMER/creativecore@2.13.2/team.creative.creativecore.common.gui.GuiControl.renderContent(GuiControl.java:421) ~[creativecore-257814-6439252.jar%23226!/:2.13.2] {re:classloading}
	at TRANSFORMER/creativecore@2.13.2/team.creative.creativecore.common.gui.GuiControl.renderContent(GuiControl.java:413) ~[creativecore-257814-6439252.jar%23226!/:2.13.2] {re:classloading}
	at TRANSFORMER/creativecore@2.13.2/team.creative.creativecore.common.gui.GuiControl.render(GuiControl.java:391) ~[creativecore-257814-6439252.jar%23226!/:2.13.2] {re:classloading}
```