### PR TITLE
Fix: Remove hasBounds() check in VectorFan.generate() to resolve compact CTM slope render issue

### DIFF
--- a/src/main/java/team/creative/creativecore/common/util/math/geo/VectorFan.java
+++ b/src/main/java/team/creative/creativecore/common/util/math/geo/VectorFan.java
@@ -88,7 +88,7 @@ public class VectorFan {
     @OnlyIn(Dist.CLIENT)
     public void generate(QuadGeneratorContext holder, List<BakedQuad> quads) {
         Vec3f[] coords = this.coords;
-        if (!holder.box.allowOverlap && holder.hasBounds()) {
+        if (!holder.box.allowOverlap) {
             Axis one = holder.facing.one();
             Axis two = holder.facing.two();
             


### PR DESCRIPTION
<img width="1920" height="1080" alt="8CDBAF80C756FE13E52C64F18CE1465C_compressed" src="https://github.com/user-attachments/assets/78a6d68f-4e85-4894-b521-366d50d4d17e" />
<img width="1920" height="1080" alt="0F82EE8C26F30F2649F65F9879D3BDB5" src="https://github.com/user-attachments/assets/c35416af-931e-420f-9119-d9c32f0db032" />
