### PR TITLE
Use same range calculations on both platforms

### DIFF
--- a/src/fabric/java/team/creative/creativecore/common/util/mc/PlayerUtils.java
+++ b/src/fabric/java/team/creative/creativecore/common/util/mc/PlayerUtils.java
@@ -32,10 +32,7 @@ public class PlayerUtils {
     }
     
     public static double getReach(Player player) {
-        double attrib = 5.0;
-        // TODO: Find out how to do this
-        //		double attrib = player.getAttribute(net.minecraftforge.common.ForgeMod.REACH_DISTANCE.get()).getValue();
-        
+        double attrib = player.blockInteractionRange();
         return player.isCreative() ? attrib : attrib - 0.5;
     }
     

--- a/src/forge/java/team/creative/creativecore/common/util/mc/PlayerUtils.java
+++ b/src/forge/java/team/creative/creativecore/common/util/mc/PlayerUtils.java
@@ -13,7 +13,7 @@ public class PlayerUtils {
     }
     
     public static double getReach(Player player) {
-        double attrib = player.getAttributeValue(Attributes.BLOCK_INTERACTION_RANGE);
+        double attrib = player.blockInteractionRange();
         return player.isCreative() ? attrib : attrib - 0.5;
     }
     


### PR DESCRIPTION
This changes it so that the same code is used on both platforms, allowing this class to potentially be moved into the main code.

Is it intentional that you are checking for if the player is in creative mode, when the attribute already changes value if they are?